### PR TITLE
Added toggle switch to enable/disable monitoring and show persistent …

### DIFF
--- a/.idea/.name
+++ b/.idea/.name
@@ -1,0 +1,1 @@
+ZapAlert

--- a/.idea/appInsightsSettings.xml
+++ b/.idea/appInsightsSettings.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AppInsightsSettings">
+    <option name="tabSettings">
+      <map>
+        <entry key="Firebase Crashlytics">
+          <value>
+            <InsightsFilterSettings>
+              <option name="connection">
+                <ConnectionSetting>
+                  <option name="appId" value="PLACEHOLDER" />
+                  <option name="mobileSdkAppId" value="" />
+                  <option name="projectId" value="" />
+                  <option name="projectNumber" value="" />
+                </ConnectionSetting>
+              </option>
+              <option name="signal" value="SIGNAL_UNSPECIFIED" />
+              <option name="timeIntervalDays" value="THIRTY_DAYS" />
+              <option name="visibilityType" value="ALL" />
+            </InsightsFilterSettings>
+          </value>
+        </entry>
+      </map>
+    </option>
+  </component>
+</project>

--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CompilerConfiguration">
+    <bytecodeTargetLevel target="21" />
+  </component>
+</project>

--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,10 +4,10 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2025-05-28T17:29:16.033023800Z">
+        <DropdownSelection timestamp="2025-06-23T15:44:23.422460100Z">
           <Target type="DEFAULT_BOOT">
             <handle>
-              <DeviceId pluginId="PhysicalDevice" identifier="serial=f1e546d9bcba" />
+              <DeviceId pluginId="LocalEmulator" identifier="path=C:\Users\singh\.android\avd\Pixel_7a_API_35.avd" />
             </handle>
           </Target>
         </DropdownSelection>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -22,6 +22,7 @@
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
 
     <application
         android:requestLegacyExternalStorage="true"
@@ -54,6 +55,7 @@
             android:exported="false"
             android:foregroundServiceType="phoneCall"
             android:stopWithTask="false" />
+
     </application>
 
 </manifest>

--- a/app/src/main/java/com/example/zapalert/MainActivity.kt
+++ b/app/src/main/java/com/example/zapalert/MainActivity.kt
@@ -10,9 +10,11 @@ import android.os.Bundle
 import android.widget.Button
 import android.widget.Toast
 import android.provider.Settings
+import android.widget.Switch
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
+import androidx.preference.PreferenceManager
 
 class MainActivity : AppCompatActivity() {
 
@@ -89,7 +91,26 @@ class MainActivity : AppCompatActivity() {
             startActivity(Intent(this, SettingsActivity::class.java))
         }
 
+        val monitorSwitch: Switch = findViewById(R.id.monitorSwitch)
+        val prefs = PreferenceManager.getDefaultSharedPreferences(this)
+        val isEnabled = prefs.getBoolean("call_monitor_enabled", false)
+        monitorSwitch.isChecked = isEnabled
+
+        monitorSwitch.setOnCheckedChangeListener { _, isChecked ->
+            prefs.edit().putBoolean("call_monitor_enabled", isChecked).apply()
+            if (isChecked) {
+                checkAndRequestPermissions()
+            } else {
+                stopService(Intent(this, CallNotificationService::class.java))
+                Toast.makeText(this, "Service stopped", Toast.LENGTH_SHORT).show()
+            }
+        }
+
         checkAndRequestPermissions()
+
+        if (isEnabled) {
+            startService()
+        }
     }
 
     private fun checkAndRequestPermissions() {
@@ -138,4 +159,5 @@ class MainActivity : AppCompatActivity() {
             startService(Intent(this, CallNotificationService::class.java))
         }
     }
+
 }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -8,23 +8,33 @@
     android:padding="16dp"
     tools:context=".MainActivity">
 
+    <!-- 🔘 Large toggle switch with no text -->
+    <Switch
+        android:id="@+id/monitorSwitch"
+        android:layout_width="80dp"
+        android:layout_height="48dp"
+        android:text=""
+        android:thumbTextPadding="0dp"
+        android:padding="8dp"
+        android:layout_marginBottom="32dp" />
+
     <TextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="Call Notifier"
         android:textSize="24sp"
-        android:textStyle="bold"/>
+        android:textStyle="bold" />
 
     <TextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="Monitoring incoming calls"
         android:layout_marginTop="8dp"
-        android:layout_marginBottom="32dp"/>
+        android:layout_marginBottom="32dp" />
 
     <Button
         android:id="@+id/settingsButton"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="Settings"/>
+        android:text="Settings" />
 </LinearLayout>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.8.0-alpha08"
+agp = "8.8.2"
 androidxJunit = "1.1.5"
 appcompat = "1.7.0"
 constraintlayout = "2.2.1"


### PR DESCRIPTION
This update introduces a toggle switch in the app that allows users to enable or disable monitoring of incoming phone calls.

When monitoring is enabled, the app shows a foreground notification:

“Call Notifier Active – Monitoring for incoming calls”
and it will also show notifications on incoming calls.

When monitoring is disabled, the app stops monitoring incoming calls, and no notification is shown.